### PR TITLE
chore(vercel): build root Vite app and refine ignore

### DIFF
--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -10,8 +10,8 @@ fi
 CHANGED=$(git diff --name-only "${VERCEL_GIT_PREVIOUS_COMMIT_SHA:-}" "${VERCEL_GIT_COMMIT_SHA:-}" || true)
 printf "Changed files:\n%s\n" "$CHANGED"
 
-# Proceed only if relevant paths changed
-if echo "$CHANGED" | grep -qE '^(packages/|.github/)'; then
+# Proceed if root vite app or configs changed
+if echo "$CHANGED" | grep -qE '^(src/|index.html|vite.config|package.json|public/|tailwind\.config|postcss\.config|\.github/|packages/)'; then
   echo "Proceed with build: relevant paths changed"
   exit 1
 fi

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,8 @@
   "version": 2,
   "framework": null,
   "installCommand": "npm install --ignore-scripts --legacy-peer-deps",
-  "buildCommand": "echo 'No build at root; UI packages build in Storybook/CI'",
-  "outputDirectory": "public",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "ignoreCommand": "bash vercel-ignore.sh"
 }
 


### PR DESCRIPTION
- Build root Vite app with npm run build (dist)\n- vercel-ignore.sh: trigger for root app and configs