### PR TITLE
fix(vercel): use explicit ./vercel-ignore.sh in ignoreCommand

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "installCommand": "npm install --ignore-scripts --legacy-peer-deps",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "ignoreCommand": "bash vercel-ignore.sh"
+  "ignoreCommand": "bash ./vercel-ignore.sh"
 }
 
 


### PR DESCRIPTION
Vercel failed to run ignore script by name; make path explicit to ensure script is found at repo root.